### PR TITLE
Finders now return ChargeOver objects. Fixed #4.

### DIFF
--- a/ChargeOverException.php
+++ b/ChargeOverException.php
@@ -1,0 +1,5 @@
+<?php
+
+class ChargeOverException extends \Exception
+{
+}


### PR DESCRIPTION
This commit also does a few more things.
* Simplifies the ChargeOverAPI::isError() logic.
* ChargeOverAPI ::find no longer adds WHERE and ORDER parameters if its not needed.
* If find or findById encounter an unexpected error a new ChargeOverException is thrown.
* If findById does not find anything a null value is returned.

Now code like this works.
```php
try {
   $item = $API->findById(1);
catch (ChargeOverException $e) {
    // handle error appropriately.
}

if ($item) {
    echo "We found " . $item->name;
} else {
    echo "Oh no, it doesn't exist! :(";
}
```