### PR TITLE
Add Brand support

### DIFF
--- a/ChargeOverAPI.php
+++ b/ChargeOverAPI.php
@@ -429,7 +429,7 @@ class ChargeOverAPI
 			ChargeOverAPI_Object::TYPE_QUOTE => 'ChargeOverAPI_Object_Quote',
 			ChargeOverAPI_Object::TYPE_TRANSACTION => 'ChargeOverAPI_Object_Transaction',
 			ChargeOverAPI_Object::TYPE_ACH => 'ChargeOverAPI_Object_Ach',
-            ChargeOverAPI_Object::TYPE_BRAND => 'ChargeOverAPI_Object_Brand',
+			ChargeOverAPI_Object::TYPE_BRAND => 'ChargeOverAPI_Object_Brand',
 			ChargeOverAPI_Object::TYPE_USAGE => 'ChargeOverAPI_Object_Usage',
 			ChargeOverAPI_Object::TYPE_ITEM => 'ChargeOverAPI_Object_Item',
 			ChargeOverAPI_Object::TYPE_ITEMCATEGORY => 'ChargeOverAPI_Object_ItemCategory',

--- a/ChargeOverAPI.php
+++ b/ChargeOverAPI.php
@@ -203,7 +203,7 @@ class ChargeOverAPI
 		curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
 		curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $http_method);
 
-		// Override cURL options 
+		// Override cURL options
 		if ($this->_http)
 		{
 			foreach ($this->_http as $k => $v)
@@ -429,6 +429,7 @@ class ChargeOverAPI
 			ChargeOverAPI_Object::TYPE_QUOTE => 'ChargeOverAPI_Object_Quote',
 			ChargeOverAPI_Object::TYPE_TRANSACTION => 'ChargeOverAPI_Object_Transaction',
 			ChargeOverAPI_Object::TYPE_ACH => 'ChargeOverAPI_Object_Ach',
+            ChargeOverAPI_Object::TYPE_BRAND => 'ChargeOverAPI_Object_Brand',
 			ChargeOverAPI_Object::TYPE_USAGE => 'ChargeOverAPI_Object_Usage',
 			ChargeOverAPI_Object::TYPE_ITEM => 'ChargeOverAPI_Object_Item',
 			ChargeOverAPI_Object::TYPE_ITEMCATEGORY => 'ChargeOverAPI_Object_ItemCategory',

--- a/ChargeOverAPI/Object.php
+++ b/ChargeOverAPI/Object.php
@@ -19,6 +19,7 @@ class ChargeOverAPI_Object
 	const TYPE_CREDITCARD = 'creditcard';
 	const TYPE_TRANSACTION = 'transaction';
 	const TYPE_ACH = 'ach';
+    const TYPE_BRAND = 'brand';
 	const TYPE_USAGE = 'usage';
 	const TYPE_NOTE = 'note';
 	const TYPE_COUNTRY = 'country';

--- a/ChargeOverAPI/Object.php
+++ b/ChargeOverAPI/Object.php
@@ -19,7 +19,7 @@ class ChargeOverAPI_Object
 	const TYPE_CREDITCARD = 'creditcard';
 	const TYPE_TRANSACTION = 'transaction';
 	const TYPE_ACH = 'ach';
-    const TYPE_BRAND = 'brand';
+	const TYPE_BRAND = 'brand';
 	const TYPE_USAGE = 'usage';
 	const TYPE_NOTE = 'note';
 	const TYPE_COUNTRY = 'country';

--- a/ChargeOverAPI/Object/Brand.php
+++ b/ChargeOverAPI/Object/Brand.php
@@ -2,4 +2,5 @@
 
 class ChargeOverAPI_Object_Brand extends ChargeOverAPI_Object
 {
+
 }

--- a/ChargeOverAPI/Object/Brand.php
+++ b/ChargeOverAPI/Object/Brand.php
@@ -1,0 +1,5 @@
+<?php
+
+class ChargeOverAPI_Object_Brand extends ChargeOverAPI_Object
+{
+}

--- a/docs/example_get_brand_by_id.php
+++ b/docs/example_get_brand_by_id.php
@@ -1,0 +1,31 @@
+<?php
+
+header('Content-Type: text/plain');
+
+require '../ChargeOverAPI.php';
+require 'config.php';
+
+$API = new ChargeOverAPI($url, $authmode, $username, $password);
+
+//Find a brand by the ChargeOver brand ID
+$resp = $API->findById('brand', '4');
+
+
+/*
+print("\n\n\n\n");
+	print($API->lastRequest());
+	print("\n\n\n\n");
+	print($API->lastResponse());
+	print("\n\n\n\n");
+*/
+
+if (!$API->isError($resp))
+{
+	$brand = $resp->response;
+	print('SUCCESS! got back brand: ' . $brand->name);
+}
+else
+{
+	print('There was an error looking up the brand!' . "\n");
+}
+


### PR DESCRIPTION
Hello @keith-chargeover 

We use the brand feature in our corporate accounts (canada and united states) and there's also a section for it in the [REST API ](https://developer.chargeover.com/apidocs/rest/#brands), however this SDK didn't support it.

I have added support for brands.
Please consider merging this PR and release a new tag 🙏🏻 

Thanks!