### PR TITLE
chore: adds the allowdynamicproperties attribute to the object class

### DIFF
--- a/ChargeOverAPI/Object.php
+++ b/ChargeOverAPI/Object.php
@@ -5,6 +5,7 @@ if (!defined('JSON_PRETTY_PRINT'))
 	define('JSON_PRETTY_PRINT', null);
 }
 
+#[AllowDynamicProperties]
 class ChargeOverAPI_Object
 {
 	const TYPE_CUSTOMER = 'customer';


### PR DESCRIPTION
Adds the allowing of dynamic properties to the object class via attributes via: https://php.watch/versions/8.2/dynamic-properties-deprecated#__get-__set