### PR TITLE
chore: fixes class_exists null deprecation

### DIFF
--- a/ChargeOverAPI.php
+++ b/ChargeOverAPI.php
@@ -722,7 +722,7 @@ class ChargeOverAPI
 				}
 			}
 
-			if (class_exists($class))
+			if (!is_null($class) && class_exists($class))
 			{
 				return new $class($arr_or_obj);
 			}


### PR DESCRIPTION
Fixes:
```
[PHP Deprecated:  class_exists(): Passing null to parameter #1 ($class) of type string is deprecated in /var/www/docker/chargeover/project/chargeover/vendor/chargeover/chargeover-php/ChargeOverAPI.php on line 725]
```